### PR TITLE
Add option to require kit for camo removal

### DIFF
--- a/addons/common/functions/fnc_canRemoveCamo.sqf
+++ b/addons/common/functions/fnc_canRemoveCamo.sqf
@@ -15,7 +15,7 @@
  * Public: Yes
  */
 
-private ["_player", "_face", "_result", "_playerItems"];
+private ["_player", "_face", "_result", "_playerItems", "_result"];
 
 _player = [_this, 0, objNull] call BIS_fnc_param;
 
@@ -23,4 +23,12 @@ if (!alive _player) exitWith {false};
 
 if (([_player] call FUNC(getCurrentCamo)) isEqualTo "") exitWith {false};
 
-[_player] call FUNC(hasAnyKit);
+_result = false;
+
+if (GVAR(require_kit_for_removal)) then {
+    _result = [_player] call FUNC(hasAnyKit);
+} else {
+    _result = true;
+};
+
+_result;

--- a/addons/common/initSettings.sqf
+++ b/addons/common/initSettings.sqf
@@ -19,3 +19,14 @@
     {},
     false
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(require_kit_for_removal),
+    "CHECKBOX",
+    [LSTRING(require_kit_for_removal), LSTRING(require_kit_for_removal_description)],
+    LSTRING(DisplayName),
+    true,
+    true,
+    {},
+    false
+] call CBA_fnc_addSetting;

--- a/addons/common/stringtable.xml
+++ b/addons/common/stringtable.xml
@@ -47,13 +47,19 @@
             <English>Application Time</English>
         </Key>
         <Key ID="STR_FISH_CAMO_CREAM_Common_application_time_description">
-            <English>Time (in seconds) it takes to apply and remove camo cream</English>
+            <English>Time (in seconds) it takes to apply and remove camo cream.</English>
         </Key>
         <Key ID="STR_FISH_CAMO_CREAM_Common_require_correct_kit">
             <English>Require Correct Kit</English>
         </Key>
         <Key ID="STR_FISH_CAMO_CREAM_Common_require_correct_kit_description">
-            <English>Require correct kit for camo types. If unchecked having a single kit will make all camo types available for application</English>
+            <English>Require correct kit for camo types. If unchecked having a single kit will make all camo types available for application.</English>
+        </Key>
+        <Key ID="STR_FISH_CAMO_CREAM_Common_require_kit_for_removal">
+            <English>Require Camo Kit for Removal</English>
+        </Key>
+        <Key ID="STR_FISH_CAMO_CREAM_Common_require_kit_for_removal_description">
+            <English>Require to have a kit in inventory in order to remove camo cream. If unchecked you can always remove camo cream.</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Fix #1 by adding an option to not require kit for camo removal
